### PR TITLE
feat: create this plugin (and add semantic-release to CI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,20 +18,20 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-  # deploy:
-  #   docker:
-  #     - image: node:12
+  deploy:
+    docker:
+      - image: node:12
 
-  #   steps:
-  #     - checkout
+    steps:
+      - checkout
 
-  #     - restore_cache:
-  #         keys:
-  #         - v1-dependencies-{{ checksum "package.json" }}
-  #         # fallback to using the latest cache if no exact match is found
-  #         - v1-dependencies-
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
 
-  #     - run: npx semantic-release
+      - run: npx semantic-release
 
   lint:
     docker:
@@ -75,11 +75,11 @@ workflows:
       - test:
           requires:
             - build
-      # - deploy:
-      #     context: reaction-publish-semantic-release
-      #     requires:
-      #       - lint
-      #       - test
-      #     filters:
-      #       branches:
-      #         only: trunk
+      - deploy:
+          context: reaction-publish-semantic-release
+          requires:
+            - lint
+            - test
+          filters:
+            branches:
+              only: trunk


### PR DESCRIPTION
This plugin replaces the internal `product` package that is currently in Reaction. It has not been tested by anyone aside myself yet, so although the changes in this particular PR only enable semantic release, please test the full functionality of the plugin before approving.

Once this PR is merged and this plugin is published to `npm`, there will be a related PR in `reaction` to swap out this plugin for the existing version.

## Testing

- `npm link` this PR into the Reaction API
- remove the existing `src/core/product/` folder to delete the current version of this plugin
- update `registerPlugins.js` inside of Reaction API to use the npm version of this package
- Start Reaction, create a product