### PR TITLE
fix: update products query argument definition

### DIFF
--- a/src/schemas/product.graphql
+++ b/src/schemas/product.graphql
@@ -619,10 +619,10 @@ extend type Query {
     "Filter by visibility"
     isVisible: Boolean
 
-    "Filter by metafield key. It uses `regex` match. To get more accurate searches send the argument as a regex pattern"
+    "Filter by metafield key using `regex` match. To get specific searches send the argument as a regex pattern"
     metafieldKey: String
 
-    "Filter by metafield value. It uses `regex` match. To get more accurate searches send the argument as a regex pattern"
+    "Filter by metafield value using `regex` match. To get specific searches send the argument as a regex pattern"
     metafieldValue: String
 
     "Filter by price range maximum value"

--- a/src/schemas/product.graphql
+++ b/src/schemas/product.graphql
@@ -619,10 +619,10 @@ extend type Query {
     "Filter by visibility"
     isVisible: Boolean
 
-    "Filter by metafield key"
+    "Filter by metafield key. It uses `regex` match. To get more accurate searches send the argument as a regex pattern"
     metafieldKey: String
 
-    "Filter by metafield value"
+    "Filter by metafield value. It uses `regex` match. To get more accurate searches send the argument as a regex pattern"
     metafieldValue: String
 
     "Filter by price range maximum value"


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #37 
Impact: **minor**
Type: **docs**

## Issue
Products query using metafields returns fuzzy matches

## Solution
Make the search logic apparent in the GraphQL definition.


## Testing
Open GraphQL playground and look at the documentation for products query. Namely the metafield arguments.
